### PR TITLE
Improve README'd 'How to Build' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ flex (>=2.6.1)
 - For instance, `apt-get install flex`
 
 Then simply run:
-bazel build zetasql/...
+`bazel build //zetasql/...`
 
 ### With docker
  TODO: Add docker build script.


### PR DESCRIPTION
Just stumbled upon this project via Hackernews -> https://news.ycombinator.com/item?id=19975722

I'm proposing a small cleanup of the `bazel build` command shown in the `README`. Not including the `//` prefix means the target is relative to to the current working directory. Including the `//` is both more typical and I think less likely to lead to user confusion, say if they happen to `cd zetasql` and then run that cmd. 🤷‍♂ 


### References:

- https://docs.bazel.build/versions/master/guide.html#build