### PR TITLE
Add Analyzer#buildStatement and fix TableRefProto serialization issue

### DIFF
--- a/java/com/google/zetasql/Analyzer.java
+++ b/java/com/google/zetasql/Analyzer.java
@@ -82,7 +82,7 @@ public class Analyzer implements Serializable {
         catalog, fileDescriptorSetsBuilder, response);
   }
 
-  public static String buildStatement(ResolvedNodes.ResolvedStatement statement, SimpleCatalog catalog) {
+  public static String buildStatement(ResolvedStatement statement, SimpleCatalog catalog) {
 
     LocalService.BuildSqlRequest.Builder request = LocalService.BuildSqlRequest.newBuilder();
     FileDescriptorSetsBuilder fileDescriptorSetsBuilder =

--- a/java/com/google/zetasql/Analyzer.java
+++ b/java/com/google/zetasql/Analyzer.java
@@ -82,6 +82,25 @@ public class Analyzer implements Serializable {
         catalog, fileDescriptorSetsBuilder, response);
   }
 
+  public static String buildStatement(ResolvedNodes.ResolvedStatement statement, SimpleCatalog catalog) {
+
+    LocalService.BuildSqlRequest.Builder request = LocalService.BuildSqlRequest.newBuilder();
+    FileDescriptorSetsBuilder fileDescriptorSetsBuilder =
+        AnalyzerHelper.serializeSimpleCatalog(catalog, request);
+    AnyResolvedStatementProto.Builder resolvedExpr = AnyResolvedStatementProto.newBuilder();
+    statement.serialize(fileDescriptorSetsBuilder, resolvedExpr);
+    request.setResolvedStatement(resolvedExpr.build());
+
+    LocalService.BuildSqlResponse response;
+    try {
+      response = Client.getStub().buildSql(request.build());
+    } catch (StatusRuntimeException e) {
+      throw new SqlException(e);
+    }
+
+    return response.getSql();
+  }
+
   /**
    * Renders expression as a sql string.
    *

--- a/java/com/google/zetasql/resolvedast/ResolvedNodes.java.template
+++ b/java/com/google/zetasql/resolvedast/ResolvedNodes.java.template
@@ -152,7 +152,7 @@ public final class ResolvedNodes {
   }
 
   static TableRefProto serialize(Table table, FileDescriptorSetsBuilder fileDescriptorSetsBuilder) {
-    return TableRefProto.newBuilder().setName(table.getName()).setSerializationId(table.getId()).build();
+    return TableRefProto.newBuilder().setFullName(table.getFullName()).setName(table.getName()).setSerializationId(table.getId()).build();
   }
 
   static TypeProto serialize(Type type, FileDescriptorSetsBuilder fileDescriptorSetsBuilder) {

--- a/zetasql/local_service/local_service.cc
+++ b/zetasql/local_service/local_service.cc
@@ -597,13 +597,13 @@ zetasql_base::Status ZetaSqlLocalServiceImpl::BuildSql(const BuildSqlRequest& re
 
   std::unique_ptr<ResolvedNode> ast;
   if (request.has_resolved_statement()) {
-    ast = std::move(ResolvedStatement::RestoreFrom(request.resolved_statement(),
-                                                   restore_params)
-                        .ValueOrDie());
+    ZETASQL_ASSIGN_OR_RETURN(
+      ast, std::move(ResolvedStatement::RestoreFrom(request.resolved_statement(),
+                                                    restore_params)));
   } else if (request.has_resolved_expression()) {
-    ast = std::move(
-        ResolvedExpr::RestoreFrom(request.resolved_expression(), restore_params)
-            .ValueOrDie());
+    ZETASQL_ASSIGN_OR_RETURN(
+      ast, std::move(ResolvedExpr::RestoreFrom(request.resolved_expression(), 
+                                               restore_params)));
   } else {
     return ::zetasql_base::OkStatus();
   }


### PR DESCRIPTION
cc @apilloud @matthewcbrown 
related: https://github.com/google/zetasql/issues/8

`Analyzer#buildStatement` doesn't work without fixing serialization of `TableRefProto`, it dies and crashes the library. This PR fixes serialization and returns an invalid status instead of dying.