### PR TITLE
Fix error: no matching function for call to 'max' on MacOS Mojave.

### DIFF
--- a/zetasql/public/types/simple_type.cc
+++ b/zetasql/public/types/simple_type.cc
@@ -1074,7 +1074,7 @@ SimpleType::ResolveNumericBignumericTypeParameters(
     const int max_precision =
         IsNumericType() ? kNumericMaxPrecision : kBigNumericMaxPrecision;
     int64_t precision = resolved_type_parameters[0].GetValue().int64_value();
-    if (precision < std::max(1l, scale) || precision > max_precision + scale) {
+    if (precision < std::max((int64_t)1, scale) || precision > max_precision + scale) {
       if (resolved_type_parameters.size() == 1) {
         return MakeSqlError()
                << "In " << ShortTypeName(mode)


### PR DESCRIPTION
zetasql/public/types/simple_type.cc:1077:21: error: no matching function for call to 'max'
    if (precision < std::max(1l, scale) || precision > max_precision + scale) {
                    ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2529:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'long long')
max(const _Tp& __a, const _Tp& __b)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2539:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'long'
max(initializer_list<_Tp> __t, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2521:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
max(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2547:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
max(initializer_list<_Tp> __t)