### PR TITLE
EXCEPT DISTINCT parsed to EXCEPT ALL + order_by and window_frame are an optional field

### DIFF
--- a/zetasql/resolved_ast/gen_resolved_ast.py
+++ b/zetasql/resolved_ast/gen_resolved_ast.py
@@ -1481,7 +1481,7 @@ def main(argv):
 
       <window_frame> can be NULL.
               """,
-      fields=[Field('window_frame', 'ResolvedWindowFrame', tag_id=2)])
+      fields=[Field('window_frame', 'ResolvedWindowFrame', tag_id=2, ignorable=IGNORABLE)])
 
   gen.AddNode(
       name='ResolvedExtendedCastElement',

--- a/zetasql/resolved_ast/gen_resolved_ast.py
+++ b/zetasql/resolved_ast/gen_resolved_ast.py
@@ -4701,7 +4701,7 @@ right.
               """,
       fields=[
           Field('partition_by', 'ResolvedWindowPartitioning', tag_id=2),
-          Field('order_by', 'ResolvedWindowOrdering', tag_id=3),
+          Field('order_by', 'ResolvedWindowOrdering', tag_id=3, ignorable=IGNORABLE),
           Field(
               'analytic_function_list',
               'ResolvedComputedColumn',

--- a/zetasql/resolved_ast/sql_builder.cc
+++ b/zetasql/resolved_ast/sql_builder.cc
@@ -2568,7 +2568,7 @@ std::pair<std::string, std::string> GetOpTypePair(
     case ResolvedSetOperationScan::EXCEPT_ALL:
       return std::make_pair("EXCEPT", "ALL");
     case ResolvedSetOperationScan::EXCEPT_DISTINCT:
-      return std::make_pair("EXCEPT", "ALL");
+      return std::make_pair("EXCEPT", "DISTINCT");
   }
 }
 


### PR DESCRIPTION
- EXCEPT DISTINCT is mapped to EXCEPT ALL after being parsed, this is now fixed
- order_by in ResolvedAnalyticFunctionGroup can be NULL and should thus be optional
- window_frame in ResolvedAnalyticFunctionCall can be NULL and should thus be optional