### PR TITLE
docs(readme): fix ZetaSQL reference after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GoogleSQL implements the GoogleSQL language, which is used across several of
 Google's SQL products, both publicly and internally, including BigQuery,
 Spanner, F1, BigTable, Dremel, Procella, and others.
 
-GoogleSQL and GoogleSQL have been described in these publications:
+GoogleSQL and ZetaSQL have been described in these publications:
 
 *   (CDMS 2022) [GoogleSQL: A SQL Language as a Component](https://cdmsworkshop.github.io/2022/Slides/Fri_C2.5_DavidWilhite.pptx)
     (Slides)


### PR DESCRIPTION
Fixes #162

Fixes a typo in the README where GoogleSQL was duplicated.
Corrects the reference to ZetaSQL following the rename.